### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     alias( libs.plugins.enonic.defaults )
-    alias( libs.plugins.enonic.xp.base )
+    id 'com.enonic.xp.base'
 }
 
 repositories {
@@ -13,8 +13,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.enonic.xp:core-api:${xpVersion}"
-    compileOnly "com.enonic.xp:portal-api:${xpVersion}"
+    compileOnly xplibs.api.core
+    compileOnly xplibs.api.portal
     implementation 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
 
     testRuntimeOnly "com.fasterxml.jackson.core:jackson-databind:2.21.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group = com.enonic.lib
 projectName = lib-thymeleaf
-xpVersion = 8.0.0-SNAPSHOT
+xpVersion = 8.0.0-B4
 version=3.0.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@
 junit = "6.0.3"
 mockito = "5.23.0"
 enonicDefaults = "2.1.6"
-enonicXpGradle = "4.0.0-A3"
 
 [libraries]
 
@@ -15,4 +14,3 @@ mockito-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = 
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }
-enonic-xp-base = { id = "com.enonic.xp.base", version.ref = "enonicXpGradle" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName


### PR DESCRIPTION
## Summary
Upgrades `lib-thymeleaf` build wiring to XP 8 per the `xp-app-upgrader` skill.

- **`xpVersion`**: `8.0.0-SNAPSHOT` → `8.0.0-B4` (latest released XP 8 beta on the dev channel — `-SNAPSHOT` is not a published version).
- **Settings plugin added**: `settings.gradle` now applies `id 'com.enonic.xp.settings' version '4.0.0-B1'`. This is the central XP 8 plumbing that supplies the `com.enonic.xp.base` plugin version and the `xplibs.*` dependency catalog.
- **Build.gradle reorganized**:
  - Replaced the version-pinned `alias( libs.plugins.enonic.xp.base )` with the unversioned `id 'com.enonic.xp.base'` (version is now supplied by the settings plugin).
  - Migrated `compileOnly "com.enonic.xp:core-api:${xpVersion}"` and `portal-api` to the `xplibs` catalog: `xplibs.api.core` and `xplibs.api.portal`.
- **`gradle/libs.versions.toml` cleanup**: removed the now-redundant `enonicXpGradle` version and `enonic-xp-base` plugin alias.

App-only steps in the skill (settings → cms, admin tools/widgets, services/APIs/tasks, webapp, idprovider, application descriptor) were not applicable — this is a JS-exposing Java library with no descriptors.

## Validation
- `./gradlew clean build` — green (`BUILD SUCCESSFUL in 15s`, all tests pass).
- Runtime verification was **not performed** (sandbox runner is ephemeral; out of scope per task brief).

## Test plan
- [x] `./gradlew clean build` passes locally
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)