### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "2.x", "latest": true },
+    { "label": "next", "checkout": "master" }
+  ]
+}


### PR DESCRIPTION
## Summary

Branches out the XP 7 maintenance line at `2.x` (cd10776 — the post-`v2.1.1` SNAPSHOT bump) and configures master so CI treats both master and `2.x` as release branches going forward.

- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing `master` + `2.x` so `build-and-publish` recognises both as release branches.
- `.github/workflows/enonic-docgen.yml`: also fire docgen on push to `2.x`.
- `docs/versions.json`: declare `2.x` as **stable / latest** and `master` as **next**, matching the app-booster reference.

`gradle.properties` already declares `version=3.0.0-SNAPSHOT`, so no version bump is needed on master.

A companion PR will land on `2.x` itself to add the same `releaseBranch:` block (the release-tools action reads `releaseBranch:` from each branch's own workflow file).

## Test plan

- [ ] CI on this PR passes (gradle build green).
- [ ] After merge, a push to `master` is still classified as a release branch (`build.outputs.release == 'true'`).
- [ ] After the companion `2.x` PR merges, a push to `2.x` is also classified as a release branch.