### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Companion to #169. Adds the same `releaseBranch:` block on `2.x` so the release-tools action — which reads `releaseBranch:` from each branch's own workflow file — recognises pushes to `2.x` as release-branch builds.

No other Step-2 changes from #169 are copied here (no version bump, no docgen change, no `versions.json`); per the app-booster reference those are master-only.

## Test plan

- [ ] CI on this PR passes (gradle build green on `2.x`).
- [ ] After merge, a push to `2.x` is classified as a release branch (`build.outputs.release == 'true'`).