### PR TITLE
Add @enonic-types/lib-thymeleaf types package #178

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push, workflow_dispatch ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             3.x
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -38,3 +38,15 @@ check.dependsOn jacocoTestReport
 test {
     useJUnitPlatform()
 }
+
+// Assemble the @enonic-types/lib-thymeleaf npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,27 @@
+import type { ResourceKey } from "@enonic-types/core";
+
+declare module "/lib/thymeleaf" {
+    /**
+     * Rendering mode. Defaults to `HTML`. Any other value falls back to `HTML` at runtime.
+     */
+    export type TemplateMode = "HTML" | "XML" | "TEXT" | "JAVASCRIPT" | "CSS" | "RAW";
+
+    export interface RenderOptions {
+        /**
+         * Rendering mode. Defaults to `HTML`.
+         */
+        mode?: TemplateMode;
+    }
+
+    /**
+     * Renders a view using Thymeleaf.
+     *
+     * @param view Location of the view. Use `resolve(...)` to resolve a view.
+     * @param model Model that is passed to the view.
+     * @param options Rendering options.
+     * @returns The rendered output.
+     */
+    export function render(view: ResourceKey, model: Record<string, unknown>, options?: RenderOptions): string;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-thymeleaf",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Thymeleaf library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-thymeleaf",
+    "thymeleaf",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-thymeleaf#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-thymeleaf.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-thymeleaf/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a published `@enonic-types/lib-thymeleaf` TypeScript types package so consumers no longer have to hand-maintain local `/lib/thymeleaf` declarations (see e.g. `app-features/src/main/resources/types/thymeleaf.d.ts`, which was incomplete — see below).

Mirrors the scaffolding introduced for lib-mustache in enonic/lib-mustache#66.

## Typed surface

Enumerated against `src/main/resources/lib/thymeleaf.js` — one exported function:

- `render(view: ResourceKey, model: Record<string, unknown>, options?: RenderOptions): string`
  - `options.mode?: "HTML" | "XML" | "TEXT" | "JAVASCRIPT" | "CSS" | "RAW"` — default `HTML`; runtime falls back to `HTML` on any other value.

## Corrections vs the app-features declaration

The app-features copy declared just `render(view, model)` — missing the `options` parameter and `mode` union entirely. The published types cover it.

## Changes

- `types/index.d.ts` — ambient `declare module "/lib/thymeleaf"` with `render`, `RenderOptions`, and `TemplateMode`.
- `types/package.json` — `@enonic-types/lib-thymeleaf`, `types: index.d.ts`, `publishConfig.access: public`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, `version: "0.0.0"` (substituted at build time from `project.version`).
- `build.gradle` — `assembleTypes` Copy task producing `build/types/`; `jar.dependsOn assembleTypes`.
- `.github/workflows/enonic-gradle.yml` — top-level `permissions: { id-token: write, contents: write }` for OIDC trusted publishing, plus `npmPublish: true` on the `build-and-publish` step.

## Verification

- `./gradlew build` green; `build/types/` contains `index.d.ts` + `package.json` with `"version": "3.1.0-SNAPSHOT"` substituted from `project.version`.
- Type-checked against `@enonic-types/core@^8.0.0` (installed from npm) with a small consumer snippet — no TS errors on the happy paths; `@ts-expect-error` correctly fires for an unknown mode literal (e.g. lowercase `"html"`) and for a missing model argument.

Depends on enonic/release-tools#71 (merged). First publish may need npm trusted-publisher setup.

Closes #178